### PR TITLE
Vue Lumino dynamic tab title

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
-## 1.0.1 (2020-07-??)
+## 1.1.0 (2020-08-27)
 
 - Upgraded dependencies via ncu -u (only non-dev dependency updated
 was @lumino/datagrid, from 0.9.1 to 0.10.0)
+- Add support for users to define their own tab titles, allowing for
+dynamic tab titles
 
 ## 1.0.0 (2020-07-04)
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,62 @@ index 3943904..f04b13d 100644
 
 ![](docs/demo2.png)
 
+### Custom tab title
+
+By default, the component uses the Vue Component name as the tab title. So if the
+component is defined as below.
+
+```js
+export default {
+  name: 'VueComponentName'
+}
+```
+
+It means that the tab title of the component will use the title "VueComponentName".
+
+Alternatively, it is possible to define a `prop` in the `Lumino` component to be used
+for the tab title.
+
+```vue
+<Lumino ref="lumino"
+  v-on:lumino:deleted="onWidgetDeletedEvent"
+  v-on:lumino:activated="onWidgetActivatedEvent"
+  tab-title-prop="displayName"
+>
+</Lumino>
+```
+
+The `prop` **MAY** be present in each component rendered by the `Lumino` component. If the
+component does not define the `prop`, then the `Lumino` component will use the default
+value, i.e. the component name.
+
+```vue
+<Lumino ref="lumino"
+  v-on:lumino:deleted="onWidgetDeletedEvent"
+  v-on:lumino:activated="onWidgetActivatedEvent"
+  tab-title-prop="displayName"
+>
+  <!-- HelloWorld tab titles will display TAB-HW-${id} -->
+  <HelloWorld
+    v-for="id of this.helloWorldWidgets"
+    :key="id"
+    :id="id"
+    :display-name="`TAB-HW-${id}`"
+  ></HelloWorld>
+  <!-- ColoredCircle tab titles will display ${ColoredCircle.name}, IOW, `ColoredCircle` -->
+  <ColoredCircle
+    v-for="id of this.coloredCircleWidgets"
+    :key="id"
+    :id="id"
+    :color="'red'"
+  ></ColoredCircle>
+</Lumino>
+```
+
+This is specially useful if you want to display a component is wrapped by another
+component. A common example of this use case, is using a loader component such as
+Vuetify Skeleton Loader.
+
 ## Building
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export default {
 It means that the tab title of the component will use the title "VueComponentName".
 
 Alternatively, it is possible to define a `prop` in the `Lumino` component to be used
-for the tab title.
+for the tab title. The default value of that prop is "name".
 
 ```vue
 <Lumino ref="lumino"

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,7 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
     <Lumino ref="lumino"
             v-on:lumino:deleted="onWidgetDeletedEvent"
             v-on:lumino:activated="onWidgetActivatedEvent"
+            tab-title-prop="tab-title"
     >
       <!-- In this example we are adding two types of elements as tabs. The code
       of this view is using the component name plus a random number for the component
@@ -47,12 +48,14 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
         v-for="id of this.helloWorldWidgets"
         :key="id"
         :id="id"
-      ></HelloWorld>
+      >
+      </HelloWorld>
       <ColoredCircle
         v-for="id of this.coloredCircleWidgets"
         :key="id"
         :id="id"
         :color="'red'"
+        :tab-title="`${id}`"
       ></ColoredCircle>
     </Lumino>
   </div>

--- a/src/components/Lumino.vue
+++ b/src/components/Lumino.vue
@@ -52,6 +52,13 @@ export default {
    */
   name: 'Lumino',
 
+  props: {
+    tabTitleProp: {
+      type: String,
+      default: 'name'
+    }
+  },
+
   /**
    * Data for the Lumino component
    */
@@ -99,11 +106,12 @@ export default {
      * components, and then creates a related Lumino Widget for this component.
      */
     syncWidgets() {
+      const tabTitleProp = this.$props.tabTitleProp
       this.$children
         .filter(child => !this.widgets.includes(child.$attrs.id))
         .forEach(newChild => {
           const id = `${newChild.$attrs.id}`
-          const name = newChild.$options.name
+          const name = newChild.$attrs[tabTitleProp] ? newChild.$attrs[tabTitleProp] : newChild.$options.name
           this.addWidget(id, name)
           this.$nextTick(() => {
             document.getElementById(id).appendChild(newChild.$el)

--- a/src/components/example/ColoredCircle.vue
+++ b/src/components/example/ColoredCircle.vue
@@ -26,6 +26,12 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
 
 <script>
 export default {
+  /**
+   * This is the component name, which is normally used as the Lumino widget
+   * tab title. In the example app, this actually won't be used. Instead, we
+   * will display a dynamic title to demonstrate how users can do that in their
+   * own code base.
+   */
   name: 'ColoredCircle',
 
   props: {

--- a/tests/e2e/specs/lumino.spec.js
+++ b/tests/e2e/specs/lumino.spec.js
@@ -28,18 +28,19 @@ describe('Lumino component', () => {
       .get('.lm-TabBar-tabLabel')
       .contains('HelloWorld')
       .should('be.visible')
-
-    cy
-      .get('.lm-TabBar-tabLabel')
-      .contains('ColoredCircle')
-      .should('not.be.visible')
     cy
       .get('#add-colored-circle-widget-button')
       .click()
     cy
       .get('.lm-TabBar-tabLabel')
-      .contains('ColoredCircle')
-      .should('be.visible')
+      .should('have.length', 2)
+    cy
+      .get('.lm-TabBar-tabLabel')
+      .then($tabs => {
+        cy
+          .wrap($tabs[1])
+          .should('be.visible')
+      })
   })
   it('should switch correctly to a different widget', () => {
     cy.visit('/')
@@ -50,20 +51,24 @@ describe('Lumino component', () => {
     // SVG element is used only in the ColoredCircle component
     cy.get('svg')
       .should('not.be.visible')
-
     cy
       .get('#add-colored-circle-widget-button')
       .click()
     cy
       .get('.lm-TabBar-tabLabel')
-      .contains('ColoredCircle')
-      .should('be.visible')
+      .should('have.length', 2)
     cy
       .get('.lm-TabBar-tabLabel')
-      .contains('ColoredCircle')
-      .click()
-    cy.get('svg')
-      .should('be.visible')
+      .then($tabs => {
+        cy
+          .wrap($tabs[1])
+          .should('be.visible')
+        cy
+          .wrap($tabs[1])
+          .click()
+        cy.get('svg')
+          .should('be.visible')
+      })
   })
   it('should successfully close a widget', () => {
     cy.visit('/')
@@ -78,22 +83,26 @@ describe('Lumino component', () => {
     cy
       .get('#add-colored-circle-widget-button')
       .click()
-    // ColoredCircle is visible
     cy
       .get('.lm-TabBar-tabLabel')
-      .contains('ColoredCircle')
-      .should('be.visible')
-    // click the close button
+      .should('have.length', 2)
     cy
       .get('.lm-TabBar-tabLabel')
-      .contains('ColoredCircle')
-      .parent()
-      .children('.lm-TabBar-tabCloseIcon')
-      .click()
-    // ain't no more now!
-    cy
-      .get('.lm-TabBar-tabLabel')
-      .contains('ColoredCircle')
-      .should('not.be.visible')
+      .then($tabs => {
+        // ColoredCircle is visible
+        cy
+          .wrap($tabs[1])
+          .should('be.visible')
+        // click the close button
+        cy
+          .wrap($tabs[1])
+          .parent()
+          .children('.lm-TabBar-tabCloseIcon')
+          .click()
+        // ain't no more now!
+        cy
+          .get('.lm-TabBar-tabLabel')
+          .should('have.length', 1)
+      })
   })
 })


### PR DESCRIPTION
Uses a prop to define the property for the title. Uses the component[property] for the tab title when available, otherwise keeps the status quo, using the component name/

Updates docs and tests.