### PR TITLE
Update package.json: Fix property "main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.2.3-SNAPSHOT",
   "license": "Apache-2.0",
   "homepage": "https://github.com/tupilabs/vue-lumino/",
-  "main": "./dist/vue-lumino.common.js",
+  "main": "./dist/vue-lumino.js",
   "type": "module",
   "files": [
     "/dist"


### PR DESCRIPTION
The specified file of property "main" of package.json (`./dist/vue-lumino.common.js`) does not exist, and will raise error when importing. [Publint](https://publint.dev/@tupilabs/vue-lumino@1.2.2) also points this out.

This commit changes property "main" to `./dist/vue-lumino.js`.